### PR TITLE
Match on '/login/mitid' as part of private login

### DIFF
--- a/bin/mitdk-authenticate
+++ b/bin/mitdk-authenticate
@@ -305,7 +305,7 @@ INIT
 	},
 
 	# case with private only
-	'/mitid' => sub {
+	'/login/mitid' => sub {
 		my $req = shift;
 		$req->uri("https://nemlog-in.mitid.dk/login/mitid");
 		$req->header( Referer => 'https://nemlog-in.mitid.dk/login/mitid');


### PR DESCRIPTION
Tested locally and allows the system to obtain a token to fetch mit messages. 